### PR TITLE
RDK-54294,RDK-54292,RDK-54293 - Changes for passing firebolt endpoint…

### DIFF
--- a/OCIContainer/OCIContainer.h
+++ b/OCIContainer/OCIContainer.h
@@ -67,6 +67,7 @@ public:
     uint32_t getApiVersionNumber() const { return 1; };
 
 private:
+    void split(const std::string& source, char delimiter, std::vector<std::string>& outputStrings); 
     int mEventListenerId; // Dobby event listener ID
     long unsigned mOmiListenerId;
     std::shared_ptr<IDobbyProxy> mDobbyProxy; // DobbyProxy instance

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -5048,6 +5048,7 @@ namespace WPEFramework {
         {
             LOGINFOMETHOD();
             bool result = true;
+            std::string environmentVariables("");
             if (!parameters.HasLabel("client"))
             {
                 result = false;
@@ -5062,6 +5063,10 @@ namespace WPEFramework {
             {
                 result = false;
                 response["message"] = "please specify mimeType";
+            }
+            if (parameters.HasLabel("environmentVariables"))
+            {
+                environmentVariables = parameters["environmentVariables"].String();
             }
             if (result)
             {
@@ -5215,6 +5220,10 @@ namespace WPEFramework {
                     param["containerId"] = client;
                     param["bundlePath"] = bundlePath;
                     param["westerosSocket"] = display;
+                    if (!environmentVariables.empty())
+	            {		    
+                        param["environmentVariables"] = environmentVariables;
+                    }
 
                     ociContainerPlugin->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, "startContainer", param, ociContainerResult);
 


### PR DESCRIPTION
…… (#5860)

* RDK-54294,RDK-54292,RDK-54293 - Changes for passing firebolt endpoints to apps

Reason for change: pass firebolt endpoints to apps
Test Procedure: Apps should launch
Risks: Low
Priority: P1
Signed-off-by: Madana Gopal Thirumalai <madanagopal_thirumalai@comcast.com>

* RDK-54294,RDK-54292,RDK-54293 - Changes for passing firebolt endpoints to apps

Reason for change: pass firebolt endpoints to apps
Test Procedure: Apps should launch
Risks: Low
Priority: P1
Signed-off-by: Madana Gopal Thirumalai <madanagopal_thirumalai@comcast.com>